### PR TITLE
Feat/k8s naming convention hyperfy2

### DIFF
--- a/clusters/prod-cluster/organizations/numinia/age-of-ai/base/deployment.yaml
+++ b/clusters/prod-cluster/organizations/numinia/age-of-ai/base/deployment.yaml
@@ -1,12 +1,12 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: age-of-ai-deployment
+  name: hyperfy2-numinia-age-of-ai-deployment
   namespace: numinia
   labels:
     environment: pro
     app: age-of-ai
-    pod-type: age-of-ai
+    pod-type: hyperfy2-numinia-age-of-ai
   annotations:
     keda.sh/auto-scaling: "enabled"
 spec:
@@ -15,13 +15,13 @@ spec:
     matchLabels:
       app: age-of-ai
       environment: pro
-      pod-type: age-of-ai
+      pod-type: hyperfy2-numinia-age-of-ai
   template:
     metadata:
       labels:
         app: age-of-ai
         environment: pro
-        pod-type: age-of-ai
+        pod-type: hyperfy2-numinia-age-of-ai
     spec:
       serviceAccountName: aws-secret-manager-sa
       imagePullSecrets:
@@ -35,7 +35,7 @@ spec:
       volumes:
         - name: hyperfy2-persistent-storage
           persistentVolumeClaim:
-            claimName: hyperfy2-efs-claim
+            claimName: hyperfy2-numinia-age-of-ai-pvc
         - name: secrets-store
           csi:
             driver: secrets-store.csi.k8s.io
@@ -43,7 +43,7 @@ spec:
             volumeAttributes:
               secretProviderClass: aws-secrets
       containers:
-        - name: age-of-ai
+        - name: hyperfy2-numinia-age-of-ai
           image: ghcr.io/numengames/numinia-hyperfy2:sha-b598263a3eb99e5a8879da871f50c8099d64c39d
           volumeMounts:
             - name: hyperfy2-persistent-storage

--- a/clusters/prod-cluster/organizations/numinia/age-of-ai/base/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numinia/age-of-ai/base/kustomization.yaml
@@ -12,140 +12,140 @@ configMapGenerator:
 - behavior: create
   envs:
   - config.env
-  name: age-of-ai-config
+  name: hyperfy2-numinia-age-of-ai-config
 replacements:
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.MEMORY
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].resources.requests.memory
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].resources.requests.memory
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.CPU
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].resources.requests.cpu
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].resources.requests.cpu
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.LIMITS_MEMORY
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].resources.limits.memory
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].resources.limits.memory
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.LIMITS_CPU
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].resources.limits.cpu
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].resources.limits.cpu
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.WORLD_NAME
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=WORLD].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=WORLD].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.PORT
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=PORT].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=PORT].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.DOMAIN
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=DOMAIN].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=DOMAIN].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.STORAGE_PATH
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=STORAGE_PATH].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=STORAGE_PATH].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.STORAGE_NAME
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=STORAGE_NAME].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=STORAGE_NAME].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.COMMIT_HASH
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=COMMIT_HASH].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=COMMIT_HASH].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.PUBLIC_WS_URL
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=PUBLIC_WS_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=PUBLIC_WS_URL].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.PUBLIC_API_URL
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=PUBLIC_API_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=PUBLIC_API_URL].value
 - source:
     kind: ConfigMap
-    name: age-of-ai-config
+    name: hyperfy2-numinia-age-of-ai-config
     fieldPath: data.PUBLIC_ASSETS_URL
   targets:
   - select:
       kind: Deployment
-      name: age-of-ai-deployment
+      name: hyperfy2-numinia-age-of-ai-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=age-of-ai].env.[name=PUBLIC_ASSETS_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-age-of-ai].env.[name=PUBLIC_ASSETS_URL].value
 labels:
 - includeSelectors: true
   pairs:
-    app: age-of-ai
-    pod-type: age-of-ai
+    app: hyperfy2-numinia-age-of-ai
+    component: game-world

--- a/clusters/prod-cluster/organizations/numinia/age-of-ai/base/middleware.yaml
+++ b/clusters/prod-cluster/organizations/numinia/age-of-ai/base/middleware.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: age-of-ai-rewrite-static-files
+  name: hyperfy2-numinia-age-of-ai-rewrite-static-files
   namespace: numinia
 spec:
   redirectRegex:
@@ -12,7 +12,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: age-of-ai-strip-prefix
+  name: hyperfy2-numinia-age-of-ai-strip-prefix
   namespace: numinia
 spec:
   stripPrefix:
@@ -23,7 +23,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: age-of-ai-rewrite-root
+  name: hyperfy2-numinia-age-of-ai-rewrite-root
   namespace: numinia
 spec:
   redirectRegex:

--- a/clusters/prod-cluster/organizations/numinia/age-of-ai/base/persistent-volume-claim.yaml
+++ b/clusters/prod-cluster/organizations/numinia/age-of-ai/base/persistent-volume-claim.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: hyperfy2-efs-claim
+  name: hyperfy2-numinia-age-of-ai-pvc
   namespace: numinia
   labels:
     organization: numinia
-    app: age-of-ai
+    app: hyperfy2-numinia-age-of-ai
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: numinia-efs
+  storageClassName: hyperfy2-numinia-efs
   resources:
     requests:
       storage: 5Gi 

--- a/clusters/prod-cluster/organizations/numinia/age-of-ai/base/route.yaml
+++ b/clusters/prod-cluster/organizations/numinia/age-of-ai/base/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: age-of-ai-route
+  name: hyperfy2-numinia-age-of-ai-route
   namespace: numinia
 spec:
   entryPoints:
@@ -11,30 +11,30 @@ spec:
     - match: "Host(`numinia.xyz`) && Path(`/age-of-ai`)"
       kind: Rule
       middlewares:
-        - name: "age-of-ai-rewrite-root"
+        - name: "hyperfy2-numinia-age-of-ai-rewrite-root"
           namespace: numinia
       services:
-        - name: "age-of-ai"
+        - name: "hyperfy2-numinia-age-of-ai-service"
           port: 3000
 
     # Handle API and other requests to /age-of-ai/*
     - match: "Host(`numinia.xyz`) && PathPrefix(`/age-of-ai`)"
       kind: Rule
       middlewares:
-        - name: "age-of-ai-strip-prefix"
+        - name: "hyperfy2-numinia-age-of-ai-strip-prefix"
           namespace: numinia
       services:
-        - name: "age-of-ai"
+        - name: "hyperfy2-numinia-age-of-ai-service"
           port: 3000
 
     # Fix requests for static assets (rewrite to /age-of-ai/*)
     - match: "Host(`numinia.xyz`) && PathPrefix(`/`)"
       kind: Rule
       middlewares:
-        - name: "age-of-ai-rewrite-static-files"
+        - name: "hyperfy2-numinia-age-of-ai-rewrite-static-files"
           namespace: numinia
       services:
-        - name: "age-of-ai"
+        - name: "hyperfy2-numinia-age-of-ai-service"
           port: 3000
 
   tls:

--- a/clusters/prod-cluster/organizations/numinia/age-of-ai/base/service.yaml
+++ b/clusters/prod-cluster/organizations/numinia/age-of-ai/base/service.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: age-of-ai
-    pod-type: age-of-ai
-  name: age-of-ai
+  name: hyperfy2-numinia-age-of-ai-service
   namespace: numinia
+  labels:
+    app: hyperfy2-numinia-age-of-ai
+    environment: prod
+    component: game-world
 spec:
   selector:
-    app: age-of-ai
+    app: hyperfy2-numinia-age-of-ai
   ports:
     - protocol: TCP
       port: 3000

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/deployment.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/deployment.yaml
@@ -4,9 +4,9 @@ metadata:
   name: hyperfy2-numinia-alchemist-tower-deployment
   namespace: numinia
   labels:
+    environment: pro
     app: hyperfy2-numinia-alchemist-tower
-    environment: prod
-    component: game-world
+    pod-type: alchemist-tower
   annotations:
     keda.sh/auto-scaling: "enabled"
 spec:

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/deployment.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: alchemist-tower-deployment
+  name: hyperfy2-numinia-alchemist-tower-deployment
   namespace: numinia
   labels:
-    environment: pro
-    app: alchemist-tower
-    pod-type: alchemist-tower
+    app: hyperfy2-numinia-alchemist-tower
+    environment: prod
+    component: game-world
   annotations:
     keda.sh/auto-scaling: "enabled"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: alchemist-tower
+      app: hyperfy2-numinia-alchemist-tower
       environment: pro
-      pod-type: alchemist-tower
+      pod-type: hyperfy2-numinia-alchemist-tower
   template:
     metadata:
       labels:
-        app: alchemist-tower
+        app: hyperfy2-numinia-alchemist-tower
         environment: pro
-        pod-type: alchemist-tower
+        pod-type: hyperfy2-numinia-alchemist-tower
     spec:
       serviceAccountName: aws-secret-manager-sa
       imagePullSecrets:
@@ -35,7 +35,7 @@ spec:
       volumes:
         - name: hyperfy2-persistent-storage
           persistentVolumeClaim:
-            claimName: hyperfy2-efs-claim
+            claimName: hyperfy2-numinia-alchemist-tower-pvc
         - name: secrets-store
           csi:
             driver: secrets-store.csi.k8s.io
@@ -43,7 +43,7 @@ spec:
             volumeAttributes:
               secretProviderClass: aws-secrets
       containers:
-        - name: alchemist-tower
+        - name: hyperfy2-numinia-alchemist-tower
           image: ghcr.io/numengames/numinia-hyperfy2:sha-b598263a3eb99e5a8879da871f50c8099d64c39d
           volumeMounts:
             - name: hyperfy2-persistent-storage

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/kustomization.yaml
@@ -12,140 +12,140 @@ configMapGenerator:
 - behavior: create
   envs:
   - config.env
-  name: alchemist-tower-config
+  name: hyperfy2-numinia-alchemist-tower-config
 replacements:
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.MEMORY
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].resources.requests.memory
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].resources.requests.memory
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.CPU
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].resources.requests.cpu
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].resources.requests.cpu
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.LIMITS_MEMORY
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].resources.limits.memory
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].resources.limits.memory
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.LIMITS_CPU
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].resources.limits.cpu
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].resources.limits.cpu
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.WORLD_NAME
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=WORLD].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=WORLD].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.PORT
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=PORT].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=PORT].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.DOMAIN
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=DOMAIN].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=DOMAIN].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.STORAGE_PATH
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=STORAGE_PATH].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=STORAGE_PATH].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.STORAGE_NAME
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=STORAGE_NAME].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=STORAGE_NAME].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.COMMIT_HASH
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=COMMIT_HASH].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=COMMIT_HASH].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.PUBLIC_WS_URL
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=PUBLIC_WS_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=PUBLIC_WS_URL].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.PUBLIC_API_URL
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=PUBLIC_API_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=PUBLIC_API_URL].value
 - source:
     kind: ConfigMap
-    name: alchemist-tower-config
+    name: hyperfy2-numinia-alchemist-tower-config
     fieldPath: data.PUBLIC_ASSETS_URL
   targets:
   - select:
       kind: Deployment
-      name: alchemist-tower-deployment
+      name: hyperfy2-numinia-alchemist-tower-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=alchemist-tower].env.[name=PUBLIC_ASSETS_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-alchemist-tower].env.[name=PUBLIC_ASSETS_URL].value
 labels:
 - includeSelectors: true
   pairs:
-    app: alchemist-tower
-    pod-type: alchemist-tower
+    app: hyperfy2-numinia-alchemist-tower
+    pod-type: hyperfy2-numinia-alchemist-tower

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/middleware.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/middleware.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: alchemist-tower-rewrite-static-files
+  name: hyperfy2-numinia-alchemist-tower-rewrite-static-files
   namespace: numinia
 spec:
   redirectRegex:
@@ -12,7 +12,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: alchemist-tower-strip-prefix
+  name: hyperfy2-numinia-alchemist-tower-strip-prefix
   namespace: numinia
 spec:
   stripPrefix:
@@ -23,7 +23,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: alchemist-tower-rewrite-root
+  name: hyperfy2-numinia-alchemist-tower-rewrite-root
   namespace: numinia
 spec:
   redirectRegex:

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/persistent-volume-claim.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/persistent-volume-claim.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: hyperfy2-efs-claim
+  name: hyperfy2-numinia-alchemist-tower-pvc
   namespace: numinia
   labels:
     organization: numinia
-    app: alchemist-tower
+    app: hyperfy2-numinia-alchemist-tower
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: numinia-efs
+  storageClassName: hyperfy2-numinia-efs
   resources:
     requests:
       storage: 5Gi 

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/route.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: alchemist-tower-route
+  name: hyperfy2-numinia-alchemist-tower-route
   namespace: numinia
 spec:
   entryPoints:
@@ -11,31 +11,31 @@ spec:
     - match: "Host(`numinia.xyz`) && Path(`/alchemist-tower`)"
       kind: Rule
       middlewares:
-        - name: "alchemist-tower-rewrite-root"
+        - name: "hyperfy2-numinia-alchemist-tower-rewrite-root"
           namespace: numinia
       services:
-        - name: "alchemist-tower"
+        - name: "hyperfy2-numinia-alchemist-tower-service"
           port: 3000
 
     # Handle API and other requests to /alchemist-tower/*
     - match: "Host(`numinia.xyz`) && PathPrefix(`/alchemist-tower`)"
       kind: Rule
       middlewares:
-        - name: "alchemist-tower-strip-prefix"
+        - name: "hyperfy2-numinia-alchemist-tower-strip-prefix"
           namespace: numinia
       services:
-        - name: "alchemist-tower"
+        - name: "hyperfy2-numinia-alchemist-tower-service"
           port: 3000
 
     # Fix requests for static assets (rewrite to /alchemist-tower/*)
     - match: "Host(`numinia.xyz`) && PathPrefix(`/`)"
       kind: Rule
       middlewares:
-        - name: "alchemist-tower-rewrite-static-files"
+        - name: "hyperfy2-numinia-alchemist-tower-rewrite-static-files"
           namespace: numinia
       services:
-        - name: "alchemist-tower"
+        - name: "hyperfy2-numinia-alchemist-tower-service"
           port: 3000
 
   tls:
-    secretName: numinia-tls
+    secretName: hyperfy2-numinia-tls

--- a/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/service.yaml
+++ b/clusters/prod-cluster/organizations/numinia/alchemist-tower/base/service.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: alchemist-tower
-    pod-type: alchemist-tower
-  name: alchemist-tower
+  name: hyperfy2-numinia-alchemist-tower-service
   namespace: numinia
+  labels:
+    app: hyperfy2-numinia-alchemist-tower
+    environment: prod
+    component: game-world
 spec:
   selector:
-    app: alchemist-tower
+    app: hyperfy2-numinia-alchemist-tower
   ports:
     - protocol: TCP
       port: 3000

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/deployment.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/deployment.yaml
@@ -1,27 +1,27 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: city-of-mesa-deployment
+  name: hyperfy2-numinia-city-of-mesa-deployment
   namespace: numinia
   labels:
-    environment: pro
-    app: city-of-mesa
-    pod-type: city-of-mesa
+    app: hyperfy2-numinia-city-of-mesa
+    environment: prod
+    component: game-world
   annotations:
     keda.sh/auto-scaling: "enabled"
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: city-of-mesa
-      environment: pro
-      pod-type: city-of-mesa
+      app: hyperfy2-numinia-city-of-mesa
+      environment: prod
+      component: game-world
   template:
     metadata:
       labels:
-        app: city-of-mesa
-        environment: pro
-        pod-type: city-of-mesa
+        app: hyperfy2-numinia-city-of-mesa
+        environment: prod
+        component: game-world
     spec:
       serviceAccountName: aws-secret-manager-sa
       imagePullSecrets:
@@ -35,7 +35,7 @@ spec:
       volumes:
         - name: hyperfy2-persistent-storage
           persistentVolumeClaim:
-            claimName: hyperfy2-efs-claim
+            claimName: hyperfy2-numinia-city-of-mesa-pvc
         - name: secrets-store
           csi:
             driver: secrets-store.csi.k8s.io
@@ -43,7 +43,7 @@ spec:
             volumeAttributes:
               secretProviderClass: aws-secrets
       containers:
-        - name: city-of-mesa
+        - name: hyperfy2-numinia-city-of-mesa
           image: ghcr.io/numengames/numinia-hyperfy2:sha-b598263a3eb99e5a8879da871f50c8099d64c39d
           volumeMounts:
             - name: hyperfy2-persistent-storage

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/kustomization.yaml
@@ -12,140 +12,140 @@ configMapGenerator:
 - behavior: create
   envs:
   - config.env
-  name: city-of-mesa-config
+  name: hyperfy2-numinia-city-of-mesa-config
 replacements:
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.MEMORY
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].resources.requests.memory
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].resources.requests.memory
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.CPU
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].resources.requests.cpu
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].resources.requests.cpu
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.LIMITS_MEMORY
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].resources.limits.memory
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].resources.limits.memory
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.LIMITS_CPU
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].resources.limits.cpu
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].resources.limits.cpu
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.WORLD_NAME
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=WORLD].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=WORLD].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.PORT
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=PORT].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=PORT].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.DOMAIN
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=DOMAIN].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=DOMAIN].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.STORAGE_PATH
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=STORAGE_PATH].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=STORAGE_PATH].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.STORAGE_NAME
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=STORAGE_NAME].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=STORAGE_NAME].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.COMMIT_HASH
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=COMMIT_HASH].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=COMMIT_HASH].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.PUBLIC_WS_URL
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=PUBLIC_WS_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=PUBLIC_WS_URL].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.PUBLIC_API_URL
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=PUBLIC_API_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=PUBLIC_API_URL].value
 - source:
     kind: ConfigMap
-    name: city-of-mesa-config
+    name: hyperfy2-numinia-city-of-mesa-config
     fieldPath: data.PUBLIC_ASSETS_URL
   targets:
   - select:
       kind: Deployment
-      name: city-of-mesa-deployment
+      name: hyperfy2-numinia-city-of-mesa-deployment
     fieldPaths:
-    - spec.template.spec.containers.[name=city-of-mesa].env.[name=PUBLIC_ASSETS_URL].value
+    - spec.template.spec.containers.[name=hyperfy2-numinia-city-of-mesa].env.[name=PUBLIC_ASSETS_URL].value
 labels:
 - includeSelectors: true
   pairs:
-    app: city-of-mesa
-    pod-type: city-of-mesa
+    app: hyperfy2-numinia-city-of-mesa
+    pod-type: hyperfy2-numinia-city-of-mesa

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/middleware.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/middleware.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: city-of-mesa-rewrite-static-files
+  name: hyperfy2-numinia-city-of-mesa-rewrite-static-files
   namespace: numinia
 spec:
   redirectRegex:
@@ -12,7 +12,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: city-of-mesa-strip-prefix
+  name: hyperfy2-numinia-city-of-mesa-strip-prefix
   namespace: numinia
 spec:
   stripPrefix:
@@ -23,7 +23,7 @@ spec:
 apiVersion: traefik.io/v1alpha1
 kind: Middleware
 metadata:
-  name: city-of-mesa-rewrite-root
+  name: hyperfy2-numinia-city-of-mesa-rewrite-root
   namespace: numinia
 spec:
   redirectRegex:

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/persistent-volume-claim.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/persistent-volume-claim.yaml
@@ -1,15 +1,15 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: hyperfy2-efs-claim
+  name: hyperfy2-numinia-city-of-mesa-pvc
   namespace: numinia
   labels:
     organization: numinia
-    app: city-of-mesa
+    app: hyperfy2-numinia-city-of-mesa
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: numinia-efs
+  storageClassName: hyperfy2-numinia-efs
   resources:
     requests:
-      storage: 5Gi 
+      storage: 5Gi

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/route.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/route.yaml
@@ -1,7 +1,7 @@
 apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
-  name: city-of-mesa-route
+  name: hyperfy2-numinia-city-of-mesa-route
   namespace: numinia
 spec:
   entryPoints:
@@ -11,31 +11,31 @@ spec:
     - match: "Host(`numinia.xyz`) && Path(`/city-of-mesa`)"
       kind: Rule
       middlewares:
-        - name: "city-of-mesa-rewrite-root"
+        - name: "hyperfy2-numinia-city-of-mesa-rewrite-root"
           namespace: numinia
       services:
-        - name: "city-of-mesa"
+        - name: "hyperfy2-numinia-city-of-mesa-service"
           port: 3000
 
     # Handle API and other requests to /city-of-mesa/*
     - match: "Host(`numinia.xyz`) && PathPrefix(`/city-of-mesa`)"
       kind: Rule
       middlewares:
-        - name: "city-of-mesa-strip-prefix"
+        - name: "hyperfy2-numinia-city-of-mesa-strip-prefix"
           namespace: numinia
       services:
-        - name: "city-of-mesa"
+        - name: "hyperfy2-numinia-city-of-mesa-service"
           port: 3000
 
     # Fix requests for static assets (rewrite to /city-of-mesa/*)
     - match: "Host(`numinia.xyz`) && PathPrefix(`/`)"
       kind: Rule
       middlewares:
-        - name: "city-of-mesa-rewrite-static-files"
+        - name: "hyperfy2-numinia-city-of-mesa-rewrite-static-files"
           namespace: numinia
       services:
-        - name: "city-of-mesa"
+        - name: "hyperfy2-numinia-city-of-mesa-service"
           port: 3000
 
   tls:
-    secretName: numinia-tls
+    secretName: hyperfy2-numinia-tls

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/route.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/route.yaml
@@ -38,4 +38,4 @@ spec:
           port: 3000
 
   tls:
-    secretName: hyperfy2-numinia-tls
+    secretName: numinia-tls

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/secret-provider.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/secret-provider.yaml
@@ -1,7 +1,7 @@
 apiVersion: secrets-store.csi.x-k8s.io/v1
 kind: SecretProviderClass
 metadata:
-  name: aws-secrets
+  name: numinia-city-of-mesa-aws-secrets
   namespace: numinia
 spec:
   provider: aws

--- a/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/service.yaml
+++ b/clusters/prod-cluster/organizations/numinia/city-of-mesa/base/service.yaml
@@ -1,14 +1,15 @@
 apiVersion: v1
 kind: Service
 metadata:
-  labels:
-    app: city-of-mesa
-    pod-type: city-of-mesa
-  name: city-of-mesa
+  name: hyperfy2-numinia-city-of-mesa-service
   namespace: numinia
+  labels:
+    app: hyperfy2-numinia-city-of-mesa
+    environment: prod
+    component: game-world
 spec:
   selector:
-    app: city-of-mesa
+    app: hyperfy2-numinia-city-of-mesa
   ports:
     - protocol: TCP
       port: 3000

--- a/clusters/prod-cluster/organizations/numinia/org-config/NAMING_CONVENTION.md
+++ b/clusters/prod-cluster/organizations/numinia/org-config/NAMING_CONVENTION.md
@@ -1,0 +1,90 @@
+# Numinia Kubernetes Naming Conventions
+
+This document outlines the standardized naming conventions for Kubernetes resources within the Numinia organization.
+
+## General Structure
+
+All resources follow this general pattern:
+```
+hyperfy2-numinia-<service>-<resource-type>[-<subtype>]
+```
+
+Where:
+- `hyperfy2-`: Platform prefix (always lowercase)
+- `numinia-`: Organization prefix (always lowercase)
+- `<service>`: Service name (e.g., city-of-mesa, age-of-ai)
+- `<resource-type>`: Kubernetes resource type (e.g., deployment, service)
+- `[-<subtype>]`: Optional subtype for specific cases
+
+## Resource Types
+
+### Workload Resources
+- Deployments: `hyperfy2-numinia-<service>-deployment`
+- StatefulSets: `hyperfy2-numinia-<service>-statefulset`
+- Jobs: `hyperfy2-numinia-<service>-job`
+- CronJobs: `hyperfy2-numinia-<service>-cronjob`
+
+### Network Resources
+- Services: `hyperfy2-numinia-<service>-service`
+- Ingress/Routes: `hyperfy2-numinia-<service>-route`
+- Middlewares: `hyperfy2-numinia-<service>-middleware`
+
+### Configuration Resources
+- ConfigMaps: `hyperfy2-numinia-<service>-config`
+- Secrets: `hyperfy2-numinia-<service>-secret`
+- ServiceAccounts: `hyperfy2-numinia-<service>-sa`
+
+### Storage Resources
+- PersistentVolumeClaims: `hyperfy2-numinia-<service>-pvc`
+- Volumes: `hyperfy2-numinia-<service>-volume`
+- Storage Claims: `hyperfy2-numinia-<service>-storage`
+
+## Labels
+
+Standard labels for all resources:
+```yaml
+labels:
+  app: hyperfy2-numinia-<service>
+  environment: prod
+  component: <specific-component>
+```
+
+## Environment Variables
+
+Environment variables should follow:
+- Use uppercase
+- Use service prefix
+- Format: `<SERVICE>_<VARIABLE>`
+- Example: `CITY_OF_MESA_PORT`, `AGE_OF_AI_DOMAIN`
+
+## Examples
+
+### Deployment
+```yaml
+metadata:
+  name: hyperfy2-numinia-city-of-mesa-deployment
+  labels:
+    app: hyperfy2-numinia-city-of-mesa
+    environment: prod
+```
+
+### Service
+```yaml
+metadata:
+  name: hyperfy2-numinia-city-of-mesa-service
+  labels:
+    app: hyperfy2-numinia-city-of-mesa
+    environment: prod
+```
+
+## Best Practices
+
+1. Always use lowercase for resource names
+2. Use hyphens (-) as separators in resource names
+3. Keep names concise but descriptive
+4. Maintain consistency across all services
+5. Include both platform (hyperfy2-) and organization (numinia-) prefixes in all resource names
+
+## Namespace Convention
+
+All resources should be in the `numinia` namespace unless there's a specific requirement for isolation. 

--- a/clusters/prod-cluster/organizations/numinia/org-config/storage/persistent-volume.yaml
+++ b/clusters/prod-cluster/organizations/numinia/org-config/storage/persistent-volume.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: PersistentVolume
 metadata:
-  name: numinia-efs-pv
+  name: hyperfy2-numinia-efs-pv
   labels:
     organization: numinia
 spec:
@@ -11,7 +11,7 @@ spec:
   accessModes:
     - ReadWriteMany
   persistentVolumeReclaimPolicy: Retain
-  storageClassName: numinia-efs
+  storageClassName: hyperfy2-numinia-efs
   csi:
     driver: efs.csi.aws.com
     volumeHandle: fs-08ccc6c105532a4b3 

--- a/clusters/prod-cluster/organizations/numinia/org-config/storage/storage-class.yaml
+++ b/clusters/prod-cluster/organizations/numinia/org-config/storage/storage-class.yaml
@@ -1,7 +1,7 @@
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: numinia-efs
+  name: hyperfy2-numinia-efs
   labels:
     organization: numinia
 provisioner: efs.csi.aws.com


### PR DESCRIPTION
feat(k8s): standardize resource naming convention with hyperfy2 prefix

- Add hyperfy2-numinia prefix to all Kubernetes resources
- Update naming convention documentation
- Standardize resource names across deployments, services, and configs
- Update all references in kustomization, routes, and middlewares
- Maintain consistent labeling across all resources

Resources affected:
- Deployments
- Services
- ConfigMaps
- PersistentVolumeClaims
- Middlewares
- IngressRoutes
- TLS Secrets

Breaking changes:
- All resource names have changed to follow hyperfy2-numinia-<service>-<type> pattern
- Storage class names updated
- Service references in routes updated