### PR TITLE
fix: update art-unchained GitRepository source to numinia-k8s

### DIFF
--- a/clusters/prod-cluster/flux-kustomization/kustomization.yaml
+++ b/clusters/prod-cluster/flux-kustomization/kustomization.yaml
@@ -37,7 +37,7 @@ spec:
   prune: true
   sourceRef:
     kind: GitRepository
-    name: art-unchained-k8s
+    name: numinia-k8s
     namespace: flux-system
 ---
 apiVersion: kustomize.toolkit.fluxcd.io/v1


### PR DESCRIPTION
- Changes GitRepository source from flux-system to numinia-k8s
- Aligns art-unchained configuration with other kustomizations in the cluster