### PR TITLE
feat: Add hyperfy spaces to numen games org

### DIFF
--- a/clusters/prod-cluster/organizations/numen-games/argent/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.argent.numen.games/ws"
     publicApiUrl: "https://pre.argent.numen.games/api"
     publicAssetsUrl: "https://pre.argent.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/argent/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argent-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-argent-pre"
+    orgName: "numen-games"
+    appName: "argent"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-argent"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.argent.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.argent.numen.games/ws"
+    publicApiUrl: "https://pre.argent.numen.games/api"
+    publicAssetsUrl: "https://pre.argent.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-argent"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/argent/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/argent/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.argent.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/argent/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: argent-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: argent-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: argent-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/argent/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/argent/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://argent.numen.games/ws"
     publicApiUrl: "https://argent.numen.games/api"
     publicAssetsUrl: "https://argent.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/argent/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: argent-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-argent-pro"
+    orgName: "numen-games"
+    appName: "argent"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-argent"
+    tlsSecretName: "numen-games-tls"
+    hostname: "argent.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://argent.numen.games/ws"
+    publicApiUrl: "https://argent.numen.games/api"
+    publicAssetsUrl: "https://argent.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-argent"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/argent/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/argent/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: argent.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/argent/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: argent-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: argent-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: argent-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/argent/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/argent/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.ath21.numen.games/ws"
     publicApiUrl: "https://pre.ath21.numen.games/api"
     publicAssetsUrl: "https://pre.ath21.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ath21-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-ath21-pre"
+    orgName: "numen-games"
+    appName: "ath21"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-ath21"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.ath21.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.ath21.numen.games/ws"
+    publicApiUrl: "https://pre.ath21.numen.games/api"
+    publicAssetsUrl: "https://pre.ath21.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-ath21"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/ath21/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/ath21/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.ath21.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ath21-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: ath21-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: ath21-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ath21-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-ath21-pro"
+    orgName: "numen-games"
+    appName: "ath21"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-ath21"
+    tlsSecretName: "numen-games-tls"
+    hostname: "ath21.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://ath21.numen.games/ws"
+    publicApiUrl: "https://ath21.numen.games/api"
+    publicAssetsUrl: "https://ath21.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-ath21"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/ath21/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/ath21/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: ath21.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://ath21.numen.games/ws"
     publicApiUrl: "https://ath21.numen.games/api"
     publicAssetsUrl: "https://ath21.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: ath21-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: ath21-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: ath21-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/ath21/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ath21/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backfund-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-backfund-pre"
+    orgName: "numen-games"
+    appName: "backfund"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-backfund"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.backfund.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.backfund.numen.games/ws"
+    publicApiUrl: "https://pre.backfund.numen.games/api"
+    publicAssetsUrl: "https://pre.backfund.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-backfund"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/backfund/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/backfund/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.backfund.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.backfund.numen.games/ws"
     publicApiUrl: "https://pre.backfund.numen.games/api"
     publicAssetsUrl: "https://pre.backfund.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: backfund-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: backfund-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: backfund-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://backfund.numen.games/ws"
     publicApiUrl: "https://backfund.numen.games/api"
     publicAssetsUrl: "https://backfund.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: backfund-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-backfund-pro"
+    orgName: "numen-games"
+    appName: "backfund"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-backfund"
+    tlsSecretName: "numen-games-tls"
+    hostname: "backfund.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://backfund.numen.games/ws"
+    publicApiUrl: "https://backfund.numen.games/api"
+    publicAssetsUrl: "https://backfund.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-backfund"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/backfund/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/backfund/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: backfund.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: backfund-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: backfund-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: backfund-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/backfund/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/backfund/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/carlo/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/carlo/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.carlo.numen.games/ws"
     publicApiUrl: "https://pre.carlo.numen.games/api"
     publicAssetsUrl: "https://pre.carlo.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/carlo/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/carlo/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://carlo.numen.games/ws"
     publicApiUrl: "https://carlo.numen.games/api"
     publicAssetsUrl: "https://carlo.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/christian/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/christian/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.christian.numen.games/ws"
     publicApiUrl: "https://pre.christian.numen.games/api"
     publicAssetsUrl: "https://pre.christian.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/christian/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/christian/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://christian.numen.games/ws"
     publicApiUrl: "https://christian.numen.games/api"
     publicAssetsUrl: "https://christian.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/clio/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clio-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-clio-pre"
+    orgName: "numen-games"
+    appName: "clio"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-clio"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.clio.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.clio.numen.games/ws"
+    publicApiUrl: "https://pre.clio.numen.games/api"
+    publicAssetsUrl: "https://pre.clio.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-clio"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/clio/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/clio/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.clio.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/clio/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.clio.numen.games/ws"
     publicApiUrl: "https://pre.clio.numen.games/api"
     publicAssetsUrl: "https://pre.clio.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/clio/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: clio-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: clio-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: clio-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/clio/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/clio/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: clio-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-clio-pro"
+    orgName: "numen-games"
+    appName: "clio"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-clio"
+    tlsSecretName: "numen-games-tls"
+    hostname: "clio.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://clio.numen.games/ws"
+    publicApiUrl: "https://clio.numen.games/api"
+    publicAssetsUrl: "https://clio.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-clio"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/clio/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/clio/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: clio.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/clio/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://clio.numen.games/ws"
     publicApiUrl: "https://clio.numen.games/api"
     publicAssetsUrl: "https://clio.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/clio/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: carlo-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: carlo-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: carlo-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/clio/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/clio/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.curiocards.numen.games/ws"
     publicApiUrl: "https://pre.curiocards.numen.games/api"
     publicAssetsUrl: "https://pre.curiocards.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curiocards-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-curiocards-pre"
+    orgName: "numen-games"
+    appName: "curiocards"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-curiocards"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.curiocards.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.curiocards.numen.games/ws"
+    publicApiUrl: "https://pre.curiocards.numen.games/api"
+    publicAssetsUrl: "https://pre.curiocards.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-curiocards"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/curiocards/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/curiocards/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.curiocards.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: curiocards-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: curiocards-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: curiocards-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://curiocards.numen.games/ws"
     publicApiUrl: "https://curiocards.numen.games/api"
     publicAssetsUrl: "https://curiocards.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: curiocards-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-curiocards-pro"
+    orgName: "numen-games"
+    appName: "curiocards"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-curiocards"
+    tlsSecretName: "numen-games-tls"
+    hostname: "curiocards.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://curiocards.numen.games/ws"
+    publicApiUrl: "https://curiocards.numen.games/api"
+    publicAssetsUrl: "https://curiocards.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-curiocards"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/curiocards/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/curiocards/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: curiocards.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: curiocards-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: curiocards-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: curiocards-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/curiocards/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/curiocards/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/dani/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dani-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-dani-pre"
+    orgName: "numen-games"
+    appName: "dani"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-dani"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.dani.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.dani.numen.games/ws"
+    publicApiUrl: "https://pre.dani.numen.games/api"
+    publicAssetsUrl: "https://pre.dani.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-dani"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/dani/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/dani/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.dani.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/dani/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.dani.numen.games/ws"
     publicApiUrl: "https://pre.dani.numen.games/api"
     publicAssetsUrl: "https://pre.dani.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/dani/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dani-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: dani-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: dani-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/dani/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/dani/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dani-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-dani-pro"
+    orgName: "numen-games"
+    appName: "dani"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-dani"
+    tlsSecretName: "numen-games-tls"
+    hostname: "dani.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://dani.numen.games/ws"
+    publicApiUrl: "https://dani.numen.games/api"
+    publicAssetsUrl: "https://dani.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-dani"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/dani/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/dani/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: dani.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/dani/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://dani.numen.games/ws"
     publicApiUrl: "https://dani.numen.games/api"
     publicAssetsUrl: "https://dani.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/dani/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: dani-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: dani-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: dani-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/dani/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/dani/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: devstarlight-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-devstarlight-pre"
+    orgName: "numen-games"
+    appName: "devstarlight"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-devstarlight"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.devstarlight.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.devstarlight.numen.games/ws"
+    publicApiUrl: "https://pre.devstarlight.numen.games/api"
+    publicAssetsUrl: "https://pre.devstarlight.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-devstarlight"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/devstarlight/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/devstarlight/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.devstarlight.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.devstarlight.numen.games/ws"
     publicApiUrl: "https://pre.devstarlight.numen.games/api"
     publicAssetsUrl: "https://pre.devstarlight.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: devstarlight-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: devstarlight-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: devstarlight-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://devstarlight.numen.games/ws"
     publicApiUrl: "https://devstarlight.numen.games/api"
     publicAssetsUrl: "https://devstarlight.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: devstarlight-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-devstarlight-pro"
+    orgName: "numen-games"
+    appName: "devstarlight"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-devstarlight"
+    tlsSecretName: "numen-games-tls"
+    hostname: "devstarlight.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://devstarlight.numen.games/ws"
+    publicApiUrl: "https://devstarlight.numen.games/api"
+    publicAssetsUrl: "https://devstarlight.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-devstarlight"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/devstarlight/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/devstarlight/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: devstarlight.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: devstarlight-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: devstarlight-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: devstarlight-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/devstarlight/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/engage/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/engage/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.engage.numen.games/ws"
     publicApiUrl: "https://pre.engage.numen.games/api"
     publicAssetsUrl: "https://pre.engage.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/engage/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/engage/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://engage.numen.games/ws"
     publicApiUrl: "https://engage.numen.games/api"
     publicAssetsUrl: "https://engage.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.escueladelvidrio.numen.games/ws"
     publicApiUrl: "https://pre.escueladelvidrio.numen.games/api"
     publicAssetsUrl: "https://pre.escueladelvidrio.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: escueladelvidrio-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-escueladelvidrio-pre"
+    orgName: "numen-games"
+    appName: "escueladelvidrio"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-escueladelvidrio"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.escueladelvidrio.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.escueladelvidrio.numen.games/ws"
+    publicApiUrl: "https://pre.escueladelvidrio.numen.games/api"
+    publicAssetsUrl: "https://pre.escueladelvidrio.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-escueladelvidrio"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/escueladelvidrio/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/escueladelvidrio/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.escueladelvidrio.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: escueladelvidrio-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: escueladelvidrio-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: escueladelvidrio-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://escueladelvidrio.numen.games/ws"
     publicApiUrl: "https://escueladelvidrio.numen.games/api"
     publicAssetsUrl: "https://escueladelvidrio.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: escueladelvidrio-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-escueladelvidrio-pro"
+    orgName: "numen-games"
+    appName: "escueladelvidrio"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-escueladelvidrio"
+    tlsSecretName: "numen-games-tls"
+    hostname: "escueladelvidrio.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://escueladelvidrio.numen.games/ws"
+    publicApiUrl: "https://escueladelvidrio.numen.games/api"
+    publicAssetsUrl: "https://escueladelvidrio.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-escueladelvidrio"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/escueladelvidrio/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/escueladelvidrio/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: escueladelvidrio.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: escueladelvidrio-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: escueladelvidrio-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: escueladelvidrio-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/escueladelvidrio/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/experience/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/experience/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.experience.numen.games/ws"
     publicApiUrl: "https://pre.experience.numen.games/api"
     publicAssetsUrl: "https://pre.experience.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/experience/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/experience/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://experience.numen.games/ws"
     publicApiUrl: "https://experience.numen.games/api"
     publicAssetsUrl: "https://experience.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.fernandobarrientos.numen.games/ws"
     publicApiUrl: "https://pre.fernandobarrientos.numen.games/api"
     publicAssetsUrl: "https://pre.fernandobarrientos.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fernandobarrientos-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-fernandobarrientos-pre"
+    orgName: "numen-games"
+    appName: "fernandobarrientos"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-fernandobarrientos"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.fernandobarrientos.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.fernandobarrientos.numen.games/ws"
+    publicApiUrl: "https://pre.fernandobarrientos.numen.games/api"
+    publicAssetsUrl: "https://pre.fernandobarrientos.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-fernandobarrientos"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/fernandobarrientos/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/fernandobarrientos/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.fernandobarrientos.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fernandobarrientos-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: fernandobarrientos-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: fernandobarrientos-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: fernandobarrientos-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-fernandobarrientos-pro"
+    orgName: "numen-games"
+    appName: "fernandobarrientos"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-fernandobarrientos"
+    tlsSecretName: "numen-games-tls"
+    hostname: "fernandobarrientos.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://fernandobarrientos.numen.games/ws"
+    publicApiUrl: "https://fernandobarrientos.numen.games/api"
+    publicAssetsUrl: "https://fernandobarrientos.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-fernandobarrientos"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/fernandobarrientos/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/fernandobarrientos/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: fernandobarrientos.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://fernandobarrientos.numen.games/ws"
     publicApiUrl: "https://fernandobarrientos.numen.games/api"
     publicAssetsUrl: "https://fernandobarrientos.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: fernandobarrientos-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: fernandobarrientos-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: fernandobarrientos-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/fernandobarrientos/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/ghost/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ghost/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.ghost.numen.games/ws"
     publicApiUrl: "https://pre.ghost.numen.games/api"
     publicAssetsUrl: "https://pre.ghost.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/ghost/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/ghost/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://ghost.numen.games/ws"
     publicApiUrl: "https://ghost.numen.games/api"
     publicAssetsUrl: "https://ghost.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/kevinonearth/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/kevinonearth/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.kevinonearth.numen.games/ws"
     publicApiUrl: "https://pre.kevinonearth.numen.games/api"
     publicAssetsUrl: "https://pre.kevinonearth.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/kevinonearth/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/kevinonearth/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://kevinonearth.numen.games/ws"
     publicApiUrl: "https://kevinonearth.numen.games/api"
     publicAssetsUrl: "https://kevinonearth.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/mab/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.mab.numen.games/ws"
     publicApiUrl: "https://pre.mab.numen.games/api"
     publicAssetsUrl: "https://pre.mab.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/mab/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mab-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-mab-pre"
+    orgName: "numen-games"
+    appName: "mab"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-mab"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.mab.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.mab.numen.games/ws"
+    publicApiUrl: "https://pre.mab.numen.games/api"
+    publicAssetsUrl: "https://pre.mab.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-mab"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/mab/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/mab/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.mab.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/mab/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mab-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: mab-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: mab-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/mab/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/mab/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://mab.numen.games/ws"
     publicApiUrl: "https://mab.numen.games/api"
     publicAssetsUrl: "https://mab.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/mab/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: mab-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-mab-pro"
+    orgName: "numen-games"
+    appName: "mab"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-mab"
+    tlsSecretName: "numen-games-tls"
+    hostname: "mab.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://mab.numen.games/ws"
+    publicApiUrl: "https://mab.numen.games/api"
+    publicAssetsUrl: "https://mab.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-mab"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/mab/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/mab/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: mab.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/mab/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: mab-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: mab-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: mab-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/mab/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/mab/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/maria/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/maria/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.maria.numen.games/ws"
     publicApiUrl: "https://pre.maria.numen.games/api"
     publicAssetsUrl: "https://pre.maria.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/maria/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/maria/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://maria.numen.games/ws"
     publicApiUrl: "https://maria.numen.games/api"
     publicAssetsUrl: "https://maria.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/nes/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nes-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-nes-pre"
+    orgName: "numen-games"
+    appName: "nes"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-nes"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.nes.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.nes.numen.games/ws"
+    publicApiUrl: "https://pre.nes.numen.games/api"
+    publicAssetsUrl: "https://pre.nes.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-nes"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/nes/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/nes/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.nes.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/nes/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.nes.numen.games/ws"
     publicApiUrl: "https://pre.nes.numen.games/api"
     publicAssetsUrl: "https://pre.nes.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/nes/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nes-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: nes-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: nes-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/nes/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/nes/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: nes-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-nes-pro"
+    orgName: "numen-games"
+    appName: "nes"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-nes"
+    tlsSecretName: "numen-games-tls"
+    hostname: "nes.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://nes.numen.games/ws"
+    publicApiUrl: "https://nes.numen.games/api"
+    publicAssetsUrl: "https://nes.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-nes"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/nes/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/nes/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: nes.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/nes/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://nes.numen.games/ws"
     publicApiUrl: "https://nes.numen.games/api"
     publicAssetsUrl: "https://nes.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/nes/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: nes-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: nes-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: nes-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/nes/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/nes/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/pablofm/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/pablofm/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.pablofm.numen.games/ws"
     publicApiUrl: "https://pre.pablofm.numen.games/api"
     publicAssetsUrl: "https://pre.pablofm.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/pablofm/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/pablofm/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pablofm.numen.games/ws"
     publicApiUrl: "https://pablofm.numen.games/api"
     publicAssetsUrl: "https://pablofm.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/pre-kustomization/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/pre-kustomization/kustomization.yaml
@@ -13,3 +13,17 @@ resources:
   - ../pablofm/pre
   - ../r3s3t/pre
   - ../training/pre
+  - ../argent/pre
+  - ../ath21/pre
+  - ../fernandobarrientos/pre
+  - ../spinosound/pre
+  - ../tetuanvalley/pre
+  - ../escueladelvidrio/pre
+  - ../nes/pre
+  - ../clio/pre
+  - ../devstarlight/pre
+  - ../dani/pre
+  - ../backfund/pre
+  - ../tramontana/pre
+  - ../curiocards/pre
+  - ../mab/pre

--- a/clusters/prod-cluster/organizations/numen-games/pro-kustomization/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/pro-kustomization/kustomization.yaml
@@ -13,3 +13,17 @@ resources:
   - ../pablofm/pro
   - ../r3s3t/pro
   - ../training/pro
+  - ../argent/pro
+  - ../ath21/pro
+  - ../fernandobarrientos/pro
+  - ../spinosound/pro
+  - ../tetuanvalley/pro
+  - ../escueladelvidrio/pro
+  - ../nes/pro
+  - ../clio/pro
+  - ../devstarlight/pro
+  - ../dani/pro
+  - ../backfund/pro
+  - ../tramontana/pro
+  - ../curiocards/pro
+  - ../mab/pro

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spinosound-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-spinosound-pre"
+    orgName: "numen-games"
+    appName: "spinosound"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-spinosound"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.spinosound.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.spinosound.numen.games/ws"
+    publicApiUrl: "https://pre.spinosound.numen.games/api"
+    publicAssetsUrl: "https://pre.spinosound.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-spinosound"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/spinosound/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/spinosound/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.spinosound.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.spinosound.numen.games/ws"
     publicApiUrl: "https://pre.spinosound.numen.games/api"
     publicAssetsUrl: "https://pre.spinosound.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spinosound-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: spinosound-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: spinosound-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: spinosound-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-spinosound-pro"
+    orgName: "numen-games"
+    appName: "spinosound"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-spinosound"
+    tlsSecretName: "numen-games-tls"
+    hostname: "spinosound.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://spinosound.numen.games/ws"
+    publicApiUrl: "https://spinosound.numen.games/api"
+    publicAssetsUrl: "https://spinosound.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-spinosound"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/spinosound/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/spinosound/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: spinosound.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://spinosound.numen.games/ws"
     publicApiUrl: "https://spinosound.numen.games/api"
     publicAssetsUrl: "https://spinosound.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: spinosound-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: spinosound-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: spinosound-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/spinosound/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/spinosound/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tetuanvalley-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-tetuanvalley-pre"
+    orgName: "numen-games"
+    appName: "tetuanvalley"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-tetuanvalley"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.tetuanvalley.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.tetuanvalley.numen.games/ws"
+    publicApiUrl: "https://pre.tetuanvalley.numen.games/api"
+    publicAssetsUrl: "https://pre.tetuanvalley.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-tetuanvalley"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/tetuanvalley/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/tetuanvalley/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.tetuanvalley.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.tetuanvalley.numen.games/ws"
     publicApiUrl: "https://pre.tetuanvalley.numen.games/api"
     publicAssetsUrl: "https://pre.tetuanvalley.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tetuanvalley-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: tetuanvalley-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: tetuanvalley-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://tetuanvalley.numen.games/ws"
     publicApiUrl: "https://tetuanvalley.numen.games/api"
     publicAssetsUrl: "https://tetuanvalley.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tetuanvalley-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-tetuanvalley-pro"
+    orgName: "numen-games"
+    appName: "tetuanvalley"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-tetuanvalley"
+    tlsSecretName: "numen-games-tls"
+    hostname: "tetuanvalley.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://tetuanvalley.numen.games/ws"
+    publicApiUrl: "https://tetuanvalley.numen.games/api"
+    publicAssetsUrl: "https://tetuanvalley.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-tetuanvalley"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/tetuanvalley/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/tetuanvalley/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: tetuanvalley.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tetuanvalley-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: tetuanvalley-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: tetuanvalley-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tetuanvalley/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/training/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/training/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.training.numen.games/ws"
     publicApiUrl: "https://pre.training.numen.games/api"
     publicAssetsUrl: "https://pre.training.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/training/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/training/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://training.numen.games/ws"
     publicApiUrl: "https://training.numen.games/api"
     publicAssetsUrl: "https://training.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pre/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tramontana-pre-values
+  namespace: numen-games-pre
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-tramontana-pre"
+    orgName: "numen-games"
+    appName: "tramontana"
+    environment: "pre"
+    namespace: numen-games-pre
+    serviceAccountName: "numen-games-pre"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pre-tramontana"
+    tlsSecretName: "numen-games-tls"
+    hostname: "pre.tramontana.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://pre.tramontana.numen.games/ws"
+    publicApiUrl: "https://pre.tramontana.numen.games/api"
+    publicAssetsUrl: "https://pre.tramontana.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pre-numengames-tramontana"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/tramontana/dev/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/dev/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/tramontana/dev/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "1024m"
+        memory: "2048Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: pre.tramontana.numen.games
+      namespace: numen-games-pre

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pre/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pre/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://pre.tramontana.numen.games/ws"
     publicApiUrl: "https://pre.tramontana.numen.games/api"
     publicAssetsUrl: "https://pre.tramontana.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "2000MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "1024m"
-        memory: "2048Mi"
+        cpu: "512m"
+        memory: "1024Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pre/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pre/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tramontana-pre
+  namespace: numen-games-pre
+spec:
+  interval: 5m
+  releaseName: tramontana-pre
+  targetNamespace: numen-games-pre
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: tramontana-pre-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pre/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pre/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pro/configmap-values.yaml
@@ -23,7 +23,7 @@ data:
     publicWsUrl: "https://tramontana.numen.games/ws"
     publicApiUrl: "https://tramontana.numen.games/api"
     publicAssetsUrl: "https://tramontana.numen.games/assets"
-    publicMaxUploadSize: "100MB"
+    publicMaxUploadSize: "1MB"
     dbType: "pg"
     dbPort: "5432"
     dbName: "postgres"
@@ -40,8 +40,8 @@ data:
         cpu: "256m"
         memory: "256Mi"
       limits:
-        cpu: "512m"
-        memory: "512Mi"
+        cpu: "1024m"
+        memory: "2048Mi"
     autoscaling:
       minScale: 0
       maxScale: 1

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pro/configmap-values.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pro/configmap-values.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: tramontana-pro-values
+  namespace: numen-games
+  annotations:
+    config-version: "1.0.0"
+data:
+  values.yaml: |
+    awsSecretName: "hyperfy2-numen-games-tramontana-pro"
+    orgName: "numen-games"
+    appName: "tramontana"
+    environment: "pro"
+    namespace: numen-games
+    serviceAccountName: "numen-games"
+    image:
+      repository: "ghcr.io/numengames/numinia-hyperfy2"
+      tag: "feat-full-storage-and-db-support-docker"
+    world: "pro-tramontana"
+    tlsSecretName: "numen-games-tls"
+    hostname: "tramontana.numen.games"
+    storagePath: "/mnt/hyperfy2-persistent-storage"
+    publicWsUrl: "https://tramontana.numen.games/ws"
+    publicApiUrl: "https://tramontana.numen.games/api"
+    publicAssetsUrl: "https://tramontana.numen.games/assets"
+    publicMaxUploadSize: "100MB"
+    dbType: "pg"
+    dbPort: "5432"
+    dbName: "postgres"
+    dbSchema: "pro-numengames-tramontana"
+    storageType: "aws"
+    s3BucketName: "statics.numinia.xyz"
+    s3Region: "eu-west-1"
+    s3AssetsPrefix: "hyperfy-spaces/numen-games/tramontana/latest/assets/"
+    s3CollectionsPrefix: "hyperfy-spaces/numen-games/collections/latest/"
+    s3StoragePrefix: "hyperfy-spaces/numen-games/tramontana/latest/storage/"
+    cloudfrontUrl: "https://statics.numinia.xyz"
+    resources:
+      requests:
+        cpu: "256m"
+        memory: "256Mi"
+      limits:
+        cpu: "512m"
+        memory: "512Mi"
+    autoscaling:
+      minScale: 0
+      maxScale: 1
+    domainMapping:
+      enabled: true
+      hostname: tramontana.numen.games
+      namespace: numen-games

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pro/helmrelease.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pro/helmrelease.yaml
@@ -1,0 +1,27 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: tramontana-pro
+  namespace: numen-games
+spec:
+  interval: 5m
+  releaseName: tramontana-pro
+  targetNamespace: numen-games
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    remediation:
+      retries: 3
+  chart:
+    spec:
+      chart: ./clusters/prod-cluster/base/hyperfy2-knative
+      sourceRef:
+        kind: GitRepository
+        name: flux-system
+        namespace: flux-system
+      interval: 1m
+  valuesFrom:
+    - kind: ConfigMap
+      name: tramontana-pro-values
+      valuesKey: values.yaml

--- a/clusters/prod-cluster/organizations/numen-games/tramontana/pro/kustomization.yaml
+++ b/clusters/prod-cluster/organizations/numen-games/tramontana/pro/kustomization.yaml
@@ -2,4 +2,4 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - configmap-values.yaml
-  - helmrelease.yaml
+  - helmrelease.yaml 


### PR DESCRIPTION
Add argent.numen.games, ath21.numen.games, fernandobarrientos.numen.games, spinosound.numen.games, tetuanvalley.numen.games, escueladelvidrio.numen.games, nes.numen.games, clio.numen.games, devstarlight.numen.games, dani.numen.games, backfund.numen.games, backfund.numen.games, tramontana.numen.games, curiocards.numen.games, mab.numen.games and its pre environments